### PR TITLE
Release Build Hidden Directory

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -10,8 +10,8 @@ def mkdir(name):
 		os.mkdir(name)
 
 if ARGUMENTS.get('mode', 'debug') == 'release':
-	mkdir('.release_build')
-	SConscript('SConscript', variant_dir='.release_build', duplicate=0,
+	mkdir('release_build')
+	SConscript('SConscript', variant_dir='release_build', duplicate=0,
 		exports={'mode':'release'})
 else:
 	mkdir('.debug_build')


### PR DESCRIPTION
The release build is created in a hidden folder after running SConstruct. Is this intentional?
